### PR TITLE
Fix invalid JSON in the example by removing a trailing comma

### DIFF
--- a/site/en/docs/extensions/reference/declarativeNetRequest/index.md
+++ b/site/en/docs/extensions/reference/declarativeNetRequest/index.md
@@ -351,7 +351,7 @@ is determined based on the priority of each rule and the operations specified.
       ]
     },
     "condition": { "urlFilter": "headers.com/12345", "resourceTypes": ["main_frame"] }
-  },
+  }
 ]
 ```
 


### PR DESCRIPTION
Right now, copy/pasting the example from [declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#example) doesn't load the extension:

<img width="503" alt="trailing-comma" src="https://user-images.githubusercontent.com/55838/202050493-3c099e85-88e8-40c3-b4b7-5f31e7599d6d.png">

